### PR TITLE
added env var CACHE_PUBLIC_EXPIRATION 5days

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM gatsbyjs/gatsby:latest
 
+ENV CACHE_PUBLIC_EXPIRATION 5d
+
 ADD public /pub


### PR DESCRIPTION
### Description
Added `CACHE_PUBLIC_EXPIRATION` environment variable to 5days in docker

### Benefits
Updated CACHE_PUBLIC_EXPIRATION to 5 days

### Applicable Issues
Closes #35 